### PR TITLE
Fix Vitest command in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
         run: pnpm install
 
       - name: Run tests
-        run: pnpm test run
+        run: pnpm test


### PR DESCRIPTION
Closes #81

## Summary
- Correct the test command in CI from `pnpm test run` to `pnpm test`.
- Prevents `vitest run run` / "No test files found" false failures.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Updated Vitest step command to `pnpm test` |

## Validation
- Ran `pnpm test` locally (passes).
